### PR TITLE
update base image from 21.03 to 22.03

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,8 @@
-FROM openeuler/openeuler:21.03
+FROM openeuler/openeuler:22.03-lts
 
 MAINTAINER liuqi<469227928@qq.com>
 
-RUN yum update && \
-yum install -y python3-pip git
+RUN yum install -y python3-pip git
 
 RUN pip3 install requests openpyxl pandas PyYAML xlsx2html
 


### PR DESCRIPTION
因镜像openeuler/openeuler:21.03不再维护，执行yum update时会报错，切换基础镜像为openeuler/openeuler:22.03-lts