### PR TITLE
fix syntax error about From header

### DIFF
--- a/pr_statistics.py
+++ b/pr_statistics.py
@@ -484,7 +484,7 @@ def send_email(xlsx_file, nickname, receivers):
     content = MIMEText(body_of_email, 'html', 'utf-8')
     msg.attach(content)
     msg['Subject'] = 'openEuler 待处理PR汇总'
-    msg['From'] = username
+    msg['From'] = sender
     msg['To'] = ','.join(receivers)
     try:
         if int(port) == 465:


### PR DESCRIPTION
之前username和sender值相等，故服务能正常运行，当username被更改为非邮箱后，会违反SMTP协议的语法，故将其改为发件邮箱以修复问题